### PR TITLE
setIn & update(In)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs/transmute",
-  "version": "2.0.0",
+  "version": "1.4.0",
   "description": "kind of like lodash but works with Immutable",
   "license": "MIT",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hs/transmute",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "kind of like lodash but works with Immutable",
   "license": "MIT",
   "main": "index.js",

--- a/src/__tests__/__snapshots__/update-test.js.snap
+++ b/src/__tests__/__snapshots__/update-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transmute/update updates a Map 1`] = `
+Immutable.Map {
+  "count": 2,
+}
+`;
+
+exports[`transmute/update updates an object 1`] = `
+Object {
+  "count": 2,
+}
+`;

--- a/src/__tests__/__snapshots__/updateIn-test.js.snap
+++ b/src/__tests__/__snapshots__/updateIn-test.js.snap
@@ -7,3 +7,11 @@ Immutable.Map {
   },
 }
 `;
+
+exports[`transmute/updateIn updates a nested Object 1`] = `
+Object {
+  "one": Object {
+    "two": 3,
+  },
+}
+`;

--- a/src/__tests__/set-test.js
+++ b/src/__tests__/set-test.js
@@ -2,7 +2,8 @@ import { Map } from 'immutable';
 import set from '../set';
 
 describe('set', () => {
-  const setOne = set(1, 'one');
+  const setOne = set('one', 1);
+
   it('sets a key in a Map', () => {
     expect(setOne(Map())).toMatchSnapshot();
   });

--- a/src/__tests__/setIn-test.js
+++ b/src/__tests__/setIn-test.js
@@ -1,0 +1,56 @@
+import { Map } from 'immutable';
+import setIn from '../setIn';
+
+describe('transmute/setIn', () => {
+  const setOneTwo = setIn(3, ['one', 'two']);
+
+  it('returns `value` for an empty `keyPath`', () => {
+    expect(setIn(1, [], {})).toBe(1);
+  });
+
+  it("throws if a value isn't settable", () => {
+    expect(() => setOneTwo({ one: null })).toThrow();
+    expect(() => setOneTwo({ one: undefined })).toThrow();
+    expect(() => setOneTwo({ one: 1 })).toThrow();
+  });
+
+  it('guesses at the type if a key isnt in the value', () => {
+    expect(setOneTwo({})).toEqual({ one: { two: 3 } });
+    expect(setOneTwo(Map())).toEqual(Map.of('one', Map.of('two', 3)));
+  });
+
+  describe('same type', () => {
+    it('sets in an Array', () => {
+      expect(setIn(3, [0, 1], [[1, 2]])).toEqual([[1, 3]]);
+    });
+
+    it('sets in a Map', () => {
+      expect(setOneTwo(Map.of('one', Map.of('two', 2)))).toEqual(
+        Map.of('one', Map.of('two', 3))
+      );
+    });
+
+    it('sets in an Object', () => {
+      expect(setOneTwo({ one: { two: 2 } })).toEqual({ one: { two: 3 } });
+    });
+  });
+
+  describe('mixed types', () => {
+    it('sets in an Array of Objects', () => {
+      const set1Two = setIn(3, [1, 'two']);
+      expect(set1Two([0, { two: 2 }])).toEqual([0, { two: 3 }]);
+    });
+
+    it('sets in a Map of Objects', () => {
+      expect(setOneTwo(Map.of('one', { two: 2 }))).toEqual(
+        setOneTwo(Map.of('one', { two: 3 }))
+      );
+    });
+
+    it('sets in an Object of Maps', () => {
+      expect(setOneTwo({ one: Map.of('two', 2) })).toEqual({
+        one: Map.of('two', 3),
+      });
+    });
+  });
+});

--- a/src/__tests__/setIn-test.js
+++ b/src/__tests__/setIn-test.js
@@ -1,4 +1,4 @@
-import { Map } from 'immutable';
+import { List, Map } from 'immutable';
 import setIn from '../setIn';
 
 describe('transmute/setIn', () => {
@@ -17,6 +17,11 @@ describe('transmute/setIn', () => {
   it('guesses at the type if a key isnt in the value', () => {
     expect(setOneTwo({})).toEqual({ one: { two: 3 } });
     expect(setOneTwo(Map())).toEqual(Map.of('one', Map.of('two', 3)));
+  });
+
+  it('switched to a keyed when guessing at an indexed type', () => {
+    expect(setIn(1, [0, 0], [])).toEqual([{ 0: 1 }]);
+    expect(setIn(1, [0, 0], List())).toEqual(List.of(Map.of(0, 1)));
   });
 
   describe('same type', () => {

--- a/src/__tests__/setIn-test.js
+++ b/src/__tests__/setIn-test.js
@@ -2,10 +2,10 @@ import { List, Map } from 'immutable';
 import setIn from '../setIn';
 
 describe('transmute/setIn', () => {
-  const setOneTwo = setIn(3, ['one', 'two']);
+  const setOneTwo = setIn(['one', 'two'], 3);
 
   it('returns `value` for an empty `keyPath`', () => {
-    expect(setIn(1, [], {})).toBe(1);
+    expect(setIn([], 1, {})).toBe(1);
   });
 
   it("throws if a value isn't settable", () => {
@@ -20,13 +20,13 @@ describe('transmute/setIn', () => {
   });
 
   it('switched to a keyed when guessing at an indexed type', () => {
-    expect(setIn(1, [0, 0], [])).toEqual([{ 0: 1 }]);
-    expect(setIn(1, [0, 0], List())).toEqual(List.of(Map.of(0, 1)));
+    expect(setIn([0, 0], 1, [])).toEqual([{ 0: 1 }]);
+    expect(setIn([0, 0], 1, List())).toEqual(List.of(Map.of(0, 1)));
   });
 
   describe('same type', () => {
     it('sets in an Array', () => {
-      expect(setIn(3, [0, 1], [[1, 2]])).toEqual([[1, 3]]);
+      expect(setIn([0, 1], 3, [[1, 2]])).toEqual([[1, 3]]);
     });
 
     it('sets in a Map', () => {
@@ -42,7 +42,7 @@ describe('transmute/setIn', () => {
 
   describe('mixed types', () => {
     it('sets in an Array of Objects', () => {
-      const set1Two = setIn(3, [1, 'two']);
+      const set1Two = setIn([1, 'two'], 3);
       expect(set1Two([0, { two: 2 }])).toEqual([0, { two: 3 }]);
     });
 

--- a/src/__tests__/update-test.js
+++ b/src/__tests__/update-test.js
@@ -1,0 +1,14 @@
+import { Map } from 'immutable';
+import update from '../update';
+
+describe('transmute/update', () => {
+  const incCount = update('count', n => n + 1);
+
+  it('updates a Map', () => {
+    expect(incCount(Map({ count: 1 }))).toMatchSnapshot();
+  });
+
+  it('updates an object', () => {
+    expect(incCount({ count: 1 })).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/updateIn-test.js
+++ b/src/__tests__/updateIn-test.js
@@ -2,8 +2,9 @@ import { Map } from 'immutable';
 import updateIn from '../updateIn';
 
 describe('transmute/updateIn', () => {
+  const incTwo = updateIn(['one', 'two'], n => n + 1);
+
   it('updates a nested Map', () => {
-    const incTwo = updateIn(['one', 'two'], n => n + 1);
     expect(
       incTwo(
         Map({
@@ -12,6 +13,16 @@ describe('transmute/updateIn', () => {
           }),
         })
       )
+    ).toMatchSnapshot();
+  });
+
+  it('updates a nested Object', () => {
+    expect(
+      incTwo({
+        one: {
+          two: 2,
+        },
+      })
     ).toMatchSnapshot();
   });
 });

--- a/src/getIn.js
+++ b/src/getIn.js
@@ -1,16 +1,5 @@
-import _get from './internal/_get';
+import _getIn from './internal/_getIn';
 import curry from './curry';
-
-function getIn(keyPath, subject) {
-  let value = subject;
-  for (let i = 0; i < keyPath.length; i++) {
-    if (value === undefined) {
-      break;
-    }
-    value = _get(keyPath[i], value);
-  }
-  return value;
-}
 
 /**
  * Retrieve a `keyPath` from a nested Immutable or JS structure.
@@ -31,4 +20,4 @@ function getIn(keyPath, subject) {
  * @param  {Array|Iterable|Object} subject
  * @return {any}
  */
-export default curry(getIn);
+export default curry(_getIn);

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export { default as protocol } from './protocol';
 export { default as reduce } from './reduce';
 export { default as set } from './set';
 export { default as setArity } from './setArity';
+export { default as setIn } from './setIn';
 export { default as some } from './some';
 export { default as sortBy } from './sortBy';
 export { default as throttle } from './throttle';

--- a/src/internal/TransmuteCollection.js
+++ b/src/internal/TransmuteCollection.js
@@ -135,6 +135,13 @@ export const keySeq = protocol({
   name: 'keySeq',
 });
 
+export const keyedEquivalent = protocol({
+  args: [
+    protocol.TYPE, // subject
+  ],
+  name: 'keyedEquivalent',
+});
+
 /**
  * @private
  * Returns a new value by applying `mapper` to each item in `subject`.

--- a/src/internal/__tests__/_keyedEquivalent-test.js
+++ b/src/internal/__tests__/_keyedEquivalent-test.js
@@ -1,0 +1,25 @@
+import _keyedEquivalent from '../_keyedEquivalent';
+import { List, Map, Seq, Set } from 'immutable';
+
+describe('transmute/internal/_keyedEquivalent', () => {
+  it('returns an Object for an Array', () => {
+    expect(_keyedEquivalent([])).toEqual({});
+  });
+
+  it('returns an Object for an Object', () => {
+    expect(_keyedEquivalent({})).toEqual({});
+  });
+
+  it('returns a Map for an Iterable', () => {
+    expect(_keyedEquivalent(List())).toEqual(Map());
+    expect(_keyedEquivalent(Map())).toEqual(Map());
+    expect(_keyedEquivalent(Set())).toEqual(Map());
+  });
+
+  it('returns a Keyed Seq for a Seq', () => {
+    expect(_keyedEquivalent(Seq())).toEqual(Seq.Keyed());
+    expect(_keyedEquivalent(Seq.Keyed())).toEqual(Seq.Keyed());
+    expect(_keyedEquivalent(Seq.Set())).toEqual(Seq.Keyed());
+    expect(_keyedEquivalent(Seq.Indexed())).toEqual(Seq.Keyed());
+  });
+});

--- a/src/internal/_getIn.js
+++ b/src/internal/_getIn.js
@@ -1,0 +1,12 @@
+import _get from './_get';
+
+export default function _getIn(keyPath, subject) {
+  let value = subject;
+  for (let i = 0; i < keyPath.length; i++) {
+    if (value === undefined) {
+      break;
+    }
+    value = _get(keyPath[i], value);
+  }
+  return value;
+}

--- a/src/internal/_keyedEquivalent.js
+++ b/src/internal/_keyedEquivalent.js
@@ -1,0 +1,11 @@
+import { Collection, Map, Seq } from 'immutable';
+import { keyedEquivalent } from './TransmuteCollection';
+
+const makeObject = () => ({});
+
+keyedEquivalent.implement(Array, makeObject);
+keyedEquivalent.implement(Object, makeObject);
+keyedEquivalent.implementInherited(Collection, () => Map());
+keyedEquivalent.implementInherited(Seq, () => Seq.Keyed());
+
+export default keyedEquivalent;

--- a/src/internal/_set.js
+++ b/src/internal/_set.js
@@ -1,7 +1,7 @@
 import { Iterable, is } from 'immutable';
 import { set } from './TransmuteCollection';
 
-set.implement(Array, (value, index, arr) => {
+set.implement(Array, (index, value, arr) => {
   if (is(arr[index], value)) {
     return arr;
   }
@@ -10,11 +10,11 @@ set.implement(Array, (value, index, arr) => {
   return next;
 });
 
-set.implementInherited(Iterable, (value, key, subject) => {
+set.implementInherited(Iterable, (key, value, subject) => {
   return subject.set(key, value);
 });
 
-set.implement(Object, (value, key, obj) => {
+set.implement(Object, (key, value, obj) => {
   if (is(obj[key], value)) {
     return obj;
   }

--- a/src/internal/_setIn.js
+++ b/src/internal/_setIn.js
@@ -34,7 +34,7 @@ export default function _setIn(value, keyPath, subject) {
   let result = value;
   while (setStack.length > 0) {
     const [layer, key] = setStack.pop();
-    result = _set(result, key, layer);
+    result = _set(key, result, layer);
   }
   return result;
 }

--- a/src/internal/_setIn.js
+++ b/src/internal/_setIn.js
@@ -1,7 +1,7 @@
-import _clear from './_clear';
 import _count from './_count';
 import _has from './_has';
 import _get from './_get';
+import _keyedEquivalent from './_keyedEquivalent';
 import _reduce from './_reduce';
 import _set from './_set';
 
@@ -17,7 +17,7 @@ function makeSetStack(keyPath, subject) {
       const actualValue = _get(prevKey, prevValue);
       const nextValue =
         actualValue === undefined && !_has(prevKey, prevValue)
-          ? _clear(prevValue)
+          ? _keyedEquivalent(prevValue)
           : actualValue;
       acc.push([nextValue, key]);
       return acc;

--- a/src/internal/_setIn.js
+++ b/src/internal/_setIn.js
@@ -26,7 +26,7 @@ function makeSetStack(keyPath, subject) {
   );
 }
 
-export default function _setIn(value, keyPath, subject) {
+export default function _setIn(keyPath, value, subject) {
   if (_count(keyPath) === 0) {
     return value;
   }

--- a/src/internal/_setIn.js
+++ b/src/internal/_setIn.js
@@ -1,0 +1,40 @@
+import _clear from './_clear';
+import _count from './_count';
+import _has from './_has';
+import _get from './_get';
+import _reduce from './_reduce';
+import _set from './_set';
+
+function makeSetStack(keyPath, subject) {
+  return _reduce(
+    [],
+    (acc, key) => {
+      if (!acc.length) {
+        acc.push([subject, key]);
+        return acc;
+      }
+      const [prevValue, prevKey] = acc[acc.length - 1];
+      const actualValue = _get(prevKey, prevValue);
+      const nextValue =
+        actualValue === undefined && !_has(prevKey, prevValue)
+          ? _clear(prevValue)
+          : actualValue;
+      acc.push([nextValue, key]);
+      return acc;
+    },
+    keyPath
+  );
+}
+
+export default function _setIn(value, keyPath, subject) {
+  if (_count(keyPath) === 0) {
+    return value;
+  }
+  const setStack = makeSetStack(keyPath, subject);
+  let result = value;
+  while (setStack.length > 0) {
+    const [layer, key] = setStack.pop();
+    result = _set(result, key, layer);
+  }
+  return result;
+}

--- a/src/mapKeys.js
+++ b/src/mapKeys.js
@@ -16,7 +16,7 @@ function mapKeys(keyMapper, subject) {
   }
   return _reduce(
     clear(subject),
-    (acc, value, key) => _set(value, keyMapper(key, value, subject), acc),
+    (acc, value, key) => _set(keyMapper(key, value, subject), value, acc),
     subject
   );
 }

--- a/src/merge.js
+++ b/src/merge.js
@@ -3,7 +3,7 @@ import _set from './internal/_set';
 import curry from './curry';
 
 function merge(updates, subject) {
-  return _reduce(subject, (acc, value, key) => _set(value, key, acc), updates);
+  return _reduce(subject, (acc, value, key) => _set(key, value, acc), updates);
 }
 
 /**

--- a/src/set.js
+++ b/src/set.js
@@ -1,5 +1,5 @@
-import curry from './curry';
 import _set from './internal/_set';
+import curry from './curry';
 
 /**
  * Returns a copy of `subject` with `key` set to `value`.

--- a/src/set.js
+++ b/src/set.js
@@ -5,11 +5,11 @@ import curry from './curry';
  * Returns a copy of `subject` with `key` set to `value`.
  *
  * @example
- * set(2, 'one', {one: 1});
+ * set('one', 2, {one: 1});
  * // returns {one: 2}
  *
- * @param {any} value
  * @param {any} key
+ * @param {any} value
  * @param {Array|Iterable|Object} subject
  * @return {Array|Iterable|Object}
  */

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -8,6 +8,13 @@ import curry from './curry';
  * setIn(3, ['one', 'two'], {one: {two: 2}});
  * // returns {one: {two: 3}}
  *
+ * @example <caption>Unset keyPaths will be set based on the most recent type.</caption>
+ * setIn(3, ['one', 'two'], {});
+ * // returns {one: {two: 3}}
+ *
+ * setIn(3, ['one', 'two'], Map());
+ * // returns Map { one => Map { two => 3 } }
+ *
  * @param {Array<any>|Iterable<any>} keyPath
  * @param {any} value
  * @param {Array|Iterable|Object} subject

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -9,8 +9,8 @@ import curry from './curry';
 function makeSetStack(keyPath, subject) {
   return _reduce(
     [],
-    (acc, key, index) => {
-      if (acc.length === 0) {
+    (acc, key) => {
+      if (!acc.length) {
         acc.push([subject, key]);
         return acc;
       }

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -1,4 +1,16 @@
 import _setIn from './internal/_setIn';
 import curry from './curry';
 
+/**
+ * Set the `value` at `keyPath` in a nested structure.
+ *
+ * @example
+ * setIn(3, ['one', 'two'], {one: {two: 2}});
+ * // returns {one: {two: 3}}
+ *
+ * @param {any} value
+ * @param {Array<any>|Iterable<any>} keyPath
+ * @param {Array|Iterable|Object} subject
+ * @param {Array|Iterable|Object}
+ */
 export default curry(_setIn);

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -8,8 +8,8 @@ import curry from './curry';
  * setIn(3, ['one', 'two'], {one: {two: 2}});
  * // returns {one: {two: 3}}
  *
- * @param {any} value
  * @param {Array<any>|Iterable<any>} keyPath
+ * @param {any} value
  * @param {Array|Iterable|Object} subject
  * @param {Array|Iterable|Object}
  */

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -1,43 +1,4 @@
-import _clear from './internal/_clear';
-import _count from './internal/_count';
-import _has from './internal/_has';
-import _get from './internal/_get';
-import _reduce from './internal/_reduce';
-import _set from './internal/_set';
+import _setIn from './internal/_setIn';
 import curry from './curry';
 
-function makeSetStack(keyPath, subject) {
-  return _reduce(
-    [],
-    (acc, key) => {
-      if (!acc.length) {
-        acc.push([subject, key]);
-        return acc;
-      }
-      const [prevValue, prevKey] = acc[acc.length - 1];
-      const actualValue = _get(prevKey, prevValue);
-      const nextValue =
-        actualValue === undefined && !_has(prevKey, prevValue)
-          ? _clear(prevValue)
-          : actualValue;
-      acc.push([nextValue, key]);
-      return acc;
-    },
-    keyPath
-  );
-}
-
-function setIn(value, keyPath, subject) {
-  if (_count(keyPath) === 0) {
-    return value;
-  }
-  const setStack = makeSetStack(keyPath, subject);
-  let result = value;
-  while (setStack.length > 0) {
-    const [layer, key] = setStack.pop();
-    result = _set(result, key, layer);
-  }
-  return result;
-}
-
-export default curry(setIn);
+export default curry(_setIn);

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -31,9 +31,7 @@ function setIn(value, keyPath, subject) {
   if (_count(keyPath) === 0) {
     return value;
   }
-
   const setStack = makeSetStack(keyPath, subject);
-
   let result = value;
   while (setStack.length > 0) {
     const [layer, key] = setStack.pop();

--- a/src/setIn.js
+++ b/src/setIn.js
@@ -1,0 +1,45 @@
+import _clear from './internal/_clear';
+import _count from './internal/_count';
+import _has from './internal/_has';
+import _get from './internal/_get';
+import _reduce from './internal/_reduce';
+import _set from './internal/_set';
+import curry from './curry';
+
+function makeSetStack(keyPath, subject) {
+  return _reduce(
+    [],
+    (acc, key, index) => {
+      if (acc.length === 0) {
+        acc.push([subject, key]);
+        return acc;
+      }
+      const [prevValue, prevKey] = acc[acc.length - 1];
+      const actualValue = _get(prevKey, prevValue);
+      const nextValue =
+        actualValue === undefined && !_has(prevKey, prevValue)
+          ? _clear(prevValue)
+          : actualValue;
+      acc.push([nextValue, key]);
+      return acc;
+    },
+    keyPath
+  );
+}
+
+function setIn(value, keyPath, subject) {
+  if (_count(keyPath) === 0) {
+    return value;
+  }
+
+  const setStack = makeSetStack(keyPath, subject);
+
+  let result = value;
+  while (setStack.length > 0) {
+    const [layer, key] = setStack.pop();
+    result = _set(result, key, layer);
+  }
+  return result;
+}
+
+export default curry(setIn);

--- a/src/translate.js
+++ b/src/translate.js
@@ -26,7 +26,7 @@ function translate(translation, subject) {
   return _reduce(
     result,
     (acc, transform, newKey) =>
-      _set(runTransform(transform, newKey, subject), newKey, acc),
+      _set(newKey, runTransform(transform, newKey, subject), acc),
     translation
   );
 }

--- a/src/update.js
+++ b/src/update.js
@@ -4,7 +4,7 @@ import curry from './curry';
 
 function update(key, updater, subject) {
   const value = _get(key, subject);
-  return _set(updater(value), key, subject);
+  return _set(key, updater(value), subject);
 }
 
 /**

--- a/src/update.js
+++ b/src/update.js
@@ -1,0 +1,10 @@
+import _get from './internal/_get';
+import _set from './internal/_set';
+import curry from './curry';
+
+function update(key, updater, subject) {
+  const value = _get(key, subject);
+  return _set(updater(value), key, subject);
+}
+
+export default curry(update);

--- a/src/update.js
+++ b/src/update.js
@@ -7,4 +7,12 @@ function update(key, updater, subject) {
   return _set(updater(value), key, subject);
 }
 
+/**
+ * Sets the value at `key` to the result of `updater`.
+ *
+ * @param {any} key
+ * @param {Function} updater
+ * @param {Array|Iterable|Object} subject
+ * @return {Array|Iterable|Object}
+ */
 export default curry(update);

--- a/src/update.js
+++ b/src/update.js
@@ -10,6 +10,11 @@ function update(key, updater, subject) {
 /**
  * Sets the value at `key` to the result of `updater`.
  *
+ * @example
+ * const incrementCount = update('count', n => n + 1);
+ * incrementCount({count: 1});
+ * // returns {count: 2}
+ *
  * @param {any} key
  * @param {Function} updater
  * @param {Array|Iterable|Object} subject

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -10,9 +10,9 @@ function updateIn(keyPath, updater, subject) {
 /**
  * Apply `updater` to the value at `keyPath`.
  *
- * @param  {Array<any>} keyPath the location where `updater` should be applied.
+ * @param  {Array<any>|Iterable<any>} keyPath the location where `updater` should be applied.
  * @param  {Function} updater the tranformation to apply.
- * @param  {Iterable} subject the thing to update.
- * @return {Iterable}
+ * @param  {Array|Iterable|Object} subject the thing to update.
+ * @return {Array|Iterable|Object}
  */
 export default curry(updateIn);

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -4,7 +4,7 @@ import _setIn from './internal/_setIn';
 
 function updateIn(keyPath, updater, subject) {
   const value = _getIn(keyPath, subject);
-  return _setIn(updater(value), keyPath, subject);
+  return _setIn(keyPath, updater(value), subject);
 }
 
 /**

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -10,6 +10,11 @@ function updateIn(keyPath, updater, subject) {
 /**
  * Apply `updater` to the value at `keyPath`.
  *
+ * @example
+ * const incrementUserCount = updateIn(['users', 'count'], n => n + 1);
+ * incrementUserCount({users: {count: 1}});
+ * // returns {users: {count: 2}}
+ *
  * @param  {Array<any>|Iterable<any>} keyPath the location where `updater` should be applied.
  * @param  {Function} updater the tranformation to apply.
  * @param  {Array|Iterable|Object} subject the thing to update.

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -15,6 +15,14 @@ function updateIn(keyPath, updater, subject) {
  * incrementUserCount({users: {count: 1}});
  * // returns {users: {count: 2}}
  *
+ * @example <caption>Unset keyPaths will be set based on the most recent type.</caption>
+ * const incrementUserCount = updateIn(['users', 'count'], (n = 0) => n + 1);
+ * incrementUserCount({});
+ * // returns {users: {count: 1}}
+ *
+ * incrementUserCount(Map());
+ * // returns Map { users => Map { count => 1 } }
+ *
  * @param  {Array<any>|Iterable<any>} keyPath the location where `updater` should be applied.
  * @param  {Function} updater the tranformation to apply.
  * @param  {Array|Iterable|Object} subject the thing to update.

--- a/src/updateIn.js
+++ b/src/updateIn.js
@@ -1,7 +1,10 @@
 import curry from './curry';
+import _getIn from './internal/_getIn';
+import _setIn from './internal/_setIn';
 
 function updateIn(keyPath, updater, subject) {
-  return subject.updateIn(keyPath, updater);
+  const value = _getIn(keyPath, subject);
+  return _setIn(updater(value), keyPath, subject);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,11 +2600,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
-
-indent-string@^3.2.0:
+indent-string@^3.0.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 


### PR DESCRIPTION
Matches immutable's set(in)/update(in) behavior.

Changes `set(value, key, subject)` to `set(key, value, subject)`.
Adds `setIn(keyPath, value, subject)`.
Adds `update(key, updater, subject)`.
Changes `updateIn(keyPath, updater, subject)` to use JS compatible internals.

/cc @blamattina