### PR TITLE
throttle: always clear existing timer

### DIFF
--- a/src/__tests__/throttle-test.js
+++ b/src/__tests__/throttle-test.js
@@ -1,6 +1,12 @@
 import throttle from '../throttle';
 
 describe('transmute/throttle', () => {
+  const now = Date.now;
+
+  afterAll(() => {
+    Date.now = now;
+  });
+
   const throttle100 = throttle(100);
 
   it('throws if operation is not a function', () => {
@@ -51,5 +57,29 @@ describe('transmute/throttle', () => {
     tfn.cancel();
     jest.runTimersToTime(100);
     expect(fn.mock.calls.length).toBe(1);
+  });
+
+  it('only has one delayed call at a time', () => {
+    const fn = jest.fn();
+    const tfn = throttle100(fn);
+    tfn();
+    tfn();
+    tfn();
+    jest.runTimersToTime(100);
+    expect(fn.mock.calls.length).toBe(2);
+  });
+
+  it('cancels delayed call in favor of immediate call', () => {
+    const fn = jest.fn();
+    const tfn = throttle100(fn);
+    Date.now = () => 10000;
+    tfn();
+    Date.now = () => 10050;
+    jest.runTimersToTime(50);
+    tfn();
+    jest.runTimersToTime(50);
+    Date.now = () => 10100;
+    tfn();
+    expect(fn.mock.calls.length).toBe(2);
   });
 });

--- a/src/__tests__/throttle-test.js
+++ b/src/__tests__/throttle-test.js
@@ -3,7 +3,7 @@ import throttle from '../throttle';
 describe('transmute/throttle', () => {
   const now = Date.now;
 
-  afterAll(() => {
+  afterEach(() => {
     Date.now = now;
   });
 

--- a/src/__tests__/throttle-test.js
+++ b/src/__tests__/throttle-test.js
@@ -1,13 +1,13 @@
 import throttle from '../throttle';
 
 describe('transmute/throttle', () => {
+  const throttle100 = throttle(100);
+
   const now = Date.now;
 
   afterEach(() => {
     Date.now = now;
   });
-
-  const throttle100 = throttle(100);
 
   it('throws if operation is not a function', () => {
     expect(() => throttle(100, {})).toThrow();

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -12,8 +12,10 @@ function throttle(interval, operation) {
   let timer = null;
 
   function cancel() {
-    clearTimeout(timer);
-    timer = null;
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
   }
 
   function runner() {

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -18,12 +18,12 @@ function throttle(interval, operation) {
 
   function runner() {
     lastCall = Date.now();
-    cancel();
     lastResult = operation(...lastArgs);
   }
 
   function throttled(...args) {
     lastArgs = args;
+    cancel();
     if (Date.now() - lastCall >= interval) {
       runner();
     } else {


### PR DESCRIPTION
If `throttled` enters the else block more than twice or more in a row it will schedule `setTimeout` calls and overwrite `timer` so that is lost and can never be cleared.

it is fairly easy to reproduce
```js
const fn = jest.fn();
const tfn = throttle(100, fn);
Date.now = () => 10000;
tfn();  // calls fn immediately
Date.now = () => 10025;
jest.runTimersToTime(25);
tfn(); // 25 ms since lastCall, so setTimeout, timer=1 
Date.now = () => 10050;
jest.runTimersToTime(25);
tfn(); // 50 ms since lastCall, so setTimeout, timer=2
tfn.cancel(); // clearTimeout(2), 
jest.runTimersToTime(75); // trigger timer 1 since it has been 100ms and it was never cleared
expect(fn).toHaveBeenCalledTimes(1); // Expected mock function to have been called one time, but it was called two times.

```
