### PR TITLE
Add support for Error objects to get and getIn

### DIFF
--- a/src/__tests__/get-test.js
+++ b/src/__tests__/get-test.js
@@ -6,6 +6,13 @@ describe('transmute/get', () => {
     expect(get('id')({ id: '123' }, 'random', [1, 2, 3])).toEqual('123');
   });
 
+  it('works with Error objects', () => {
+    const error = new Error();
+    error.foo = 'bar';
+    const getFoo = get('foo');
+    expect(getFoo(error)).toEqual('bar');
+  });
+
   describe('empty types', () => {
     const getTest = get('test');
 

--- a/src/__tests__/getIn-test.js
+++ b/src/__tests__/getIn-test.js
@@ -30,6 +30,15 @@ describe('transmute/getIn', () => {
     ).toMatchSnapshot();
   });
 
+  it('gets a keyPath from an Error', () => {
+    const error = new Error();
+    error.foo = {
+      bar: 'baz',
+    };
+    const fooBarGetter = getIn(['foo', 'bar']);
+    expect(fooBarGetter(error)).toEqual('baz');
+  });
+
   it('gets a keyPath from Immutables in JS Objects', () => {
     expect(
       getter({

--- a/src/internal/_get.js
+++ b/src/internal/_get.js
@@ -6,6 +6,7 @@ const empty = () => undefined;
 get.implement(Array, (key, subject) => subject[key]);
 get.implement(null, empty);
 get.implement(Object, (key, subject) => subject[key]);
+get.implement(Error, (key, subject) => subject[key]);
 get.implement(undefined, empty);
 
 get.implementInherited(Iterable, (key, subject) => subject.get(key));


### PR DESCRIPTION
Add support for `Error` objects to `get` and `getIn`.