### PR TITLE
Fix fallback support in protocol.js when undefined is implemented

### DIFF
--- a/src/__tests__/get-test.js
+++ b/src/__tests__/get-test.js
@@ -6,6 +6,13 @@ describe('transmute/get', () => {
     expect(get('id')({ id: '123' }, 'random', [1, 2, 3])).toEqual('123');
   });
 
+  it('works with Error objects', () => {
+    const error = new Error();
+    error.foo = 'bar';
+    const getFoo = get('foo');
+    expect(getFoo(error)).toEqual('bar');
+  });
+
   describe('empty types', () => {
     const getTest = get('test');
 

--- a/src/__tests__/getIn-test.js
+++ b/src/__tests__/getIn-test.js
@@ -30,6 +30,15 @@ describe('transmute/getIn', () => {
     ).toMatchSnapshot();
   });
 
+  it('gets a keyPath from an Error', () => {
+    const error = new Error();
+    error.foo = {
+      bar: 'baz',
+    };
+    const fooBarGetter = getIn(['foo', 'bar']);
+    expect(fooBarGetter(error)).toEqual('baz');
+  });
+
   it('gets a keyPath from Immutables in JS Objects', () => {
     expect(
       getter({

--- a/src/__tests__/protocol-test.js
+++ b/src/__tests__/protocol-test.js
@@ -39,6 +39,10 @@ describe('protocol', () => {
     it('dispatches to undefined', () => {
       expect(stringify(undefined)).toBe('this is undefined');
     });
+
+    it('uses the fallback when undefined has been explicitly implemented', () => {
+      expect(stringify(123)).toBe('123');
+    });
   });
 
   describe('constructor types', () => {

--- a/src/__tests__/protocol-test.js
+++ b/src/__tests__/protocol-test.js
@@ -40,7 +40,7 @@ describe('protocol', () => {
       expect(stringify(undefined)).toBe('this is undefined');
     });
 
-    it('uses the fallback when undefined has been explicitly implemented', () => {
+    it('uses the fallback when undefined has been implemented', () => {
       expect(stringify(123)).toBe('123');
     });
   });

--- a/src/internal/_get.js
+++ b/src/internal/_get.js
@@ -6,6 +6,7 @@ const empty = () => undefined;
 get.implement(Array, (key, subject) => subject[key]);
 get.implement(null, empty);
 get.implement(Object, (key, subject) => subject[key]);
+get.implement(Error, (key, subject) => subject[key]);
 get.implement(undefined, empty);
 
 get.implementInherited(Iterable, (key, subject) => subject.get(key));

--- a/src/internal/_get.js
+++ b/src/internal/_get.js
@@ -3,10 +3,7 @@ import { Iterable } from 'immutable';
 
 const empty = () => undefined;
 
-get.implement(Array, (key, subject) => subject[key]);
 get.implement(null, empty);
-get.implement(Object, (key, subject) => subject[key]);
-get.implement(Error, (key, subject) => subject[key]);
 get.implement(undefined, empty);
 
 get.implementInherited(Iterable, (key, subject) => subject.get(key));

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -63,7 +63,7 @@ export default function protocol({ args, name, fallback }: ProtocolDefinition) {
   const dispatch = _setArity(args.length, (...argValues) => {
     const value = argValues[dispatchValueIndex];
     const key = getValueKey(id, value);
-    const implementation = implementations[key] || fallback;
+    const implementation = (key && implementations[key]) || fallback;
     if (!implementation) {
       throw new Error(`${name}: not implmented for type \`${value}\``);
     }


### PR DESCRIPTION
Previously there was a bug in `protocol.js` where the fallback would never be used if there was an implementation for `undefined` provided. This was occurring for `get`, `getIn` and potentially other operators.

 When [`getValueKey`](https://github.com/HubSpot/transmute/pull/12/files#diff-79c316a20815b63cdb5a326923964967R14) was [called](https://github.com/HubSpot/transmute/pull/12/files#diff-79c316a20815b63cdb5a326923964967R65) on a value which was never implemented, it would correctly return `undefined`. When `getValueKey` was called on the value `undefined`, it would return the string `"undefined"`. When the next line evaluated [`implementations[key]`](https://github.com/HubSpot/transmute/pull/12/files#diff-79c316a20815b63cdb5a326923964967L66), both of those values would be coerced into a string and look up the implementation for the string `"undefined"`, where it would find the implementation for the value `undefined`. Therefore, for values where the fallback should have been used, `protocol.js` used the implementation for the value `undefined`.

To fix this, I first check for the truthiness of the key before evaluating `implementations[key]`.

Fixes Issue #9 (Implementing get and getIn on error objects).
Supercedes PR https://github.com/HubSpot/transmute/pull/10.