### PR TITLE
Added `scan()`

### DIFF
--- a/src/__tests__/__snapshots__/scan-test.js.snap
+++ b/src/__tests__/__snapshots__/scan-test.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transmute/scan scans a List 1`] = `
+Immutable.List [
+  Immutable.List [],
+  Immutable.List [
+    2,
+  ],
+  Immutable.List [
+    2,
+    3,
+  ],
+  Immutable.List [
+    2,
+    3,
+    4,
+  ],
+]
+`;
+
+exports[`transmute/scan scans a Map 1`] = `
+Immutable.List [
+  Immutable.Map {},
+  Immutable.Map {
+    "one": 2,
+  },
+  Immutable.Map {
+    "one": 2,
+    "two": 3,
+  },
+  Immutable.Map {
+    "one": 2,
+    "two": 3,
+    "three": 4,
+  },
+]
+`;
+
+exports[`transmute/scan scans a Seq 1`] = `
+Immutable.List [
+  Immutable.Seq [],
+  Immutable.Seq [
+    2,
+  ],
+  Immutable.Seq […],
+  Immutable.Seq […],
+]
+`;
+
+exports[`transmute/scan scans a Set 1`] = `
+Immutable.List [
+  Immutable.Set [],
+  Immutable.Set [
+    2,
+  ],
+  Immutable.Set [
+    2,
+    3,
+  ],
+  Immutable.Set [
+    2,
+    3,
+    4,
+  ],
+]
+`;
+
+exports[`transmute/scan scans an Array 1`] = `
+Immutable.List [
+  Immutable.List [],
+  Immutable.List [
+    2,
+  ],
+  Immutable.List [
+    2,
+    3,
+  ],
+  Immutable.List [
+    2,
+    3,
+    4,
+  ],
+]
+`;
+
+exports[`transmute/scan scans an Object 1`] = `
+Immutable.List [
+  Immutable.List [],
+  Immutable.List [
+    2,
+  ],
+  Immutable.List [
+    2,
+    3,
+  ],
+  Immutable.List [
+    2,
+    3,
+    4,
+  ],
+]
+`;
+
+exports[`transmute/scan scans to a primitive 1`] = `
+Immutable.List [
+  0,
+  1,
+  3,
+  6,
+]
+`;

--- a/src/__tests__/scan-test.js
+++ b/src/__tests__/scan-test.js
@@ -1,0 +1,51 @@
+import { List, Map, Seq, Set } from 'immutable';
+import scan from '../scan';
+
+describe('transmute/scan', () => {
+  it('scans an Array', () => {
+    const scanner = jest.fn((acc, n) => acc.push(n + 1));
+    expect(scan(List(), scanner, [1, 2, 3])).toMatchSnapshot();
+    expect(scanner.mock.calls.length).toBe(3);
+    expect(scanner.mock.calls[0]).toEqual([List(), 1, 0, [1, 2, 3]]);
+    expect(scanner.mock.calls[1]).toEqual([List.of(2), 2, 1, [1, 2, 3]]);
+    expect(scanner.mock.calls[2]).toEqual([List.of(2, 3), 3, 2, [1, 2, 3]]);
+  });
+
+  it('scans a List', () => {
+    expect(
+      scan(List(), (acc, n) => acc.push(n + 1), List.of(1, 2, 3))
+    ).toMatchSnapshot();
+  });
+
+  it('scans a Map', () => {
+    expect(
+      scan(
+        Map(),
+        (acc, n, k) => acc.set(k, n + 1),
+        Map({ one: 1, two: 2, three: 3 })
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('scans an Object', () => {
+    expect(
+      scan(List(), (acc, n) => acc.push(n + 1), { one: 1, two: 2, three: 3 })
+    ).toMatchSnapshot();
+  });
+
+  it('scans a Seq', () => {
+    expect(
+      scan(Seq(), (acc, n) => acc.concat([n + 1]), Seq([1, 2, 3]))
+    ).toMatchSnapshot();
+  });
+
+  it('scans a Set', () => {
+    expect(
+      scan(Set(), (acc, n) => acc.add(n + 1), Set.of(1, 2, 3))
+    ).toMatchSnapshot();
+  });
+
+  it('scans to a primitive', () => {
+    expect(scan(0)((acc, n) => acc + n)(List.of(1, 2, 3))).toMatchSnapshot();
+  });
+});

--- a/src/internal/TransmuteCollection.js
+++ b/src/internal/TransmuteCollection.js
@@ -177,6 +177,23 @@ export const reduce = protocol({
 
 /**
  * @private
+ * Returns a list of new values by applying `mapper` to each item in `subject`.
+ *
+ * @param {Function} mapper
+ * @param {TYPE} subject
+ * @return {TYPE}
+ */
+export const scan = protocol({
+  args: [
+    isAnyValue, // accumulator
+    isFunction, // reducer
+    protocol.TYPE, // subject
+  ],
+  name: 'scan',
+});
+
+/**
+ * @private
  * Set the `value` of `key` in `subject`.
  *
  * @param {any} value

--- a/src/internal/_scan.js
+++ b/src/internal/_scan.js
@@ -1,0 +1,18 @@
+import { Iterable, List } from 'immutable';
+import { scan } from './TransmuteCollection';
+import entrySeq from './_entrySeq';
+
+const scanEntries = (into, operation, src) =>
+  entrySeq(src).reduce(
+    ([acc, results], [key, val]) => {
+      const res = operation(acc, val, key, src);
+      return [res, results.push(res)];
+    },
+    [into, List([into])]
+  )[1];
+
+scan.implement(Object, scanEntries);
+scan.implement(Array, scanEntries);
+scan.implementInherited(Iterable, scanEntries);
+
+export default scan;

--- a/src/scan.js
+++ b/src/scan.js
@@ -1,0 +1,25 @@
+import curry from './curry';
+import _scan from './internal/_scan';
+
+/**
+ * scan is similar to reduce, but returns a list of successive reduced values,
+ * including the initial value
+ *
+ * @example
+ * scan(0, (acc, val) => acc + val, [1, 2, 3]);
+ * // returns List [ 0, 1, 3, 6 ]
+ *
+ * @example
+ * scan(
+ *   List(),
+ *   (acc, val) => acc.push(val),
+ *   Map({ one: 1, two: 2, three: 3 })
+ * );
+ * // returns List [ List [ ], List [ 1 ], List [ 1, 2 ], List [ 1, 2, 3 ] ]
+ *
+ * @param  {any} into
+ * @param  {Function} operation
+ * @param  {Iterable} subject   [description]
+ * @return {Iterable}
+ */
+export default curry(_scan);


### PR DESCRIPTION
Scanning is like reducing but keeping the intermediate accumulator states, [haskell docs](https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-List.html#v:scanl)