### PR TITLE
Prevent NPE in getIn by verifying objects constructor

### DIFF
--- a/src/__tests__/__snapshots__/getIn-test.js.snap
+++ b/src/__tests__/__snapshots__/getIn-test.js.snap
@@ -23,3 +23,9 @@ Object {
   "three": 3,
 }
 `;
+
+exports[`transmute/getIn gets a keyPath from an Object with no constructor 1`] = `
+Object {
+  "three": 3,
+}
+`;

--- a/src/__tests__/get-test.js
+++ b/src/__tests__/get-test.js
@@ -52,6 +52,18 @@ describe('transmute/get', () => {
       expect(getTwo({ one: 1, two: 2, three: 3 })).toEqual(2);
     });
 
+    it('gets a property from an Object with no constructor', () => {
+      expect(
+        getTwo(
+          Object.create(null, {
+            one: { value: 1 },
+            two: { value: 2 },
+            three: { value: 3 },
+          })
+        )
+      ).toEqual(2);
+    });
+
     it('gets a property from a Seq', () => {
       expect(getTwo(Seq({ one: 1, two: 2, three: 3 }))).toEqual(2);
     });

--- a/src/__tests__/getIn-test.js
+++ b/src/__tests__/getIn-test.js
@@ -30,6 +30,22 @@ describe('transmute/getIn', () => {
     ).toMatchSnapshot();
   });
 
+  it('gets a keyPath from an Object with no constructor', () => {
+    expect(
+      getter(
+        Object.create(null, {
+          one: {
+            value: {
+              two: {
+                three: 3,
+              },
+            },
+          },
+        })
+      )
+    ).toMatchSnapshot();
+  });
+
   it('gets a keyPath from an Error', () => {
     const error = new Error();
     error.foo = {

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -17,7 +17,7 @@ function getValueKey(id, value) {
     case undefined:
       return `${value}`;
     default:
-      return value.constructor[id] || value[id];
+      return (value.constructor && value.constructor[id]) || value[id];
   }
 }
 


### PR DESCRIPTION
## Status: 🚀 

## Description

`getIn` throws NPE on objects without constructors. I originally encountered this error when parsing deeply nested graphQL response data from `useQuery`.

Objects created via Object.create may lack constructors:

![image](https://user-images.githubusercontent.com/5571242/68956321-d6979000-0795-11ea-916d-15225b967062.png)

cc @also @kj800x (I saw you are among the most regular maintainers)